### PR TITLE
Ignore AdvancedOpenScreenPayload to prevent opening mod-registered screens during replay

### DIFF
--- a/src/main/java/com/replaymod/replay/FullReplaySender.java
+++ b/src/main/java/com/replaymod/replay/FullReplaySender.java
@@ -41,6 +41,7 @@ import net.minecraft.network.packet.s2c.play.*;
 import net.minecraft.network.packet.s2c.login.LoginSuccessS2CPacket;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec3d;
+import net.neoforged.neoforge.network.payload.AdvancedOpenScreenPayload;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -581,6 +582,11 @@ public class FullReplaySender extends ChannelInboundHandlerAdapter implements Re
 
             if (channelNameStr.startsWith("fabric-screen-handler-api-v")) {
                 return null; // we do not want to show modded screens which got opened for the recording player
+            }
+
+            //noinspection UnstableApiUsage
+            if(packet.payload() instanceof AdvancedOpenScreenPayload) {
+                return null;
             }
 
             // On 1.14+ there's a dedicated OpenWrittenBookS2CPacket now


### PR DESCRIPTION
* fixed #52
* fixed #59
* fixed #61
* fixed #63