### PR TITLE
Make replay restrict channel optional and include render fixes

### DIFF
--- a/src/main/java/com/replaymod/recording/ReplayModRecording.java
+++ b/src/main/java/com/replaymod/recording/ReplayModRecording.java
@@ -73,7 +73,7 @@ public class ReplayModRecording implements Module {
 
     @SubscribeEvent
     static void registerNetwork(RegisterPayloadHandlersEvent event) {
-        final PayloadRegistrar registrar = event.registrar("1");
+        final PayloadRegistrar registrar = event.registrar("1").optional();
         registrar.commonToClient(Restrictions.ID, Restrictions.CODEC, (payload, context) -> {});
     }
 

--- a/src/main/java/com/replaymod/render/Setting.java
+++ b/src/main/java/com/replaymod/render/Setting.java
@@ -9,4 +9,6 @@ public final class Setting<T> {
             new SettingsRegistry.SettingKeys<>("advanced", "skipPostRenderGui", null, false);
     public static final SettingsRegistry.SettingKey<Boolean> FRAME_TIME_FROM_WORLD_TIME =
             new SettingsRegistry.SettingKeys<>("render", "frameTimeFromWorldTime", null, false);
+    public static final SettingsRegistry.SettingKey<Integer> SKIN_PRELOAD_DELAY =
+            new SettingsRegistry.SettingKeys<>("render", "skinPreloadDelay", null, 3);
 }

--- a/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
+++ b/src/main/java/com/replaymod/render/rendering/VideoRenderer.java
@@ -12,6 +12,7 @@ import com.replaymod.render.EXRWriter;
 import com.replaymod.render.PNGWriter;
 import com.replaymod.render.RenderSettings;
 import com.replaymod.render.ReplayModRender;
+import com.replaymod.render.Setting;
 import com.replaymod.render.FFmpegWriter;
 import com.replaymod.render.blend.BlendState;
 import com.replaymod.render.capturer.RenderInfo;
@@ -196,18 +197,26 @@ public class VideoRenderer implements RenderInfo {
 
         ReplayTimer timer = (ReplayTimer) ((MinecraftAccessor) mc).getTimer();
 
-        // Play up to one second before starting to render
+        // Play up to several seconds before starting to render
         // This is necessary in order to ensure that all entities have at least two position packets
         // and their first position in the recording is correct.
+        // Additionally, this gives time for player skins to load from the network.
         // Note that it is impossible to also get the interpolation between their latest position
         // and the one in the recording correct as there's no reliable way to tell when the server ticks
         // or when we should be done with the interpolation of the entity
+        int preloadDelaySeconds = 3; // Default value, try to read from config
+        try {
+            preloadDelaySeconds = ReplayModRender.instance.getCore().getSettingsRegistry().get(Setting.SKIN_PRELOAD_DELAY);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to load skin preload delay setting, using default value of 3 seconds", e);
+        }
+        int preloadDelayMs = preloadDelaySeconds * 1000;
         Optional<Integer> optionalVideoStartTime = timeline.getValue(TimestampProperty.PROPERTY, 0);
         if (optionalVideoStartTime.isPresent()) {
             int videoStart = optionalVideoStartTime.get();
 
-            if (videoStart > 1000) {
-                int replayTime = videoStart - 1000;
+            if (videoStart > preloadDelayMs) {
+                int replayTime = videoStart - preloadDelayMs;
                 //#if MC>=11200
                 timer.tickDelta = 0;
                 ((TimerAccessor) timer).setTickLength(DEFAULT_MS_PER_TICK);


### PR DESCRIPTION
## Summary
- Mark `replaymod:restrict` payload registration as optional to avoid disconnect when server does not provide this channel
- Include additional render-related fixes from local working changes

## Details
- `ReplayModRecording.registerNetwork`: changed registrar to `event.registrar("1").optional()`
- Included existing local modifications in:
  - `src/main/java/com/replaymod/render/Setting.java`
  - `src/main/java/com/replaymod/render/rendering/VideoRenderer.java`

## Validation
- `./gradlew compileJava --no-daemon`
- `./gradlew build --no-daemon` (build successful)
